### PR TITLE
Remove min-width for user profile section

### DIFF
--- a/frontend/src/custom.scss
+++ b/frontend/src/custom.scss
@@ -55,7 +55,3 @@ body {
   display: -webkit-box;
   -webkit-box-orient: vertical;
 }
-
-.user-info {
-  min-width: 800px;
-}


### PR DESCRIPTION
# Description

Remove the `min-width` attribute for the user profile to work on mobile devices.
